### PR TITLE
Avoid NaN

### DIFF
--- a/lib/fluent/plugin/change_finder.rb
+++ b/lib/fluent/plugin/change_finder.rb
@@ -60,7 +60,7 @@ module Fluent
     def smooth(size)
       _end = @data.size
       _begin = [_end - size, 0].max
-      @data.slice(_begin, _end).inject(0.0) { |sum, v| sum += v } / (_end - _begin)
+      (_size = (_end - _begin)) == 0 ? 0.0 : @data.slice(_begin, _end).inject(:+).to_f / _size
     end
 
     def show_status

--- a/test/plugin/test_out_anomalydetect.rb
+++ b/test/plugin/test_out_anomalydetect.rb
@@ -108,8 +108,7 @@ class AnomalyDetectOutputTest < Test::Unit::TestCase
       smooth_term 3
     ]
 
-    data = (0..10).map do || (rand * 100).to_i end
-    data.push 0
+    data = 10.times.map { (rand * 100).to_i } + [0]
     d.run do 
       data.each do |val|
         (0..val - 1).each do ||
@@ -117,6 +116,49 @@ class AnomalyDetectOutputTest < Test::Unit::TestCase
         end
         r = d.instance.flush
         assert_equal val, r['target']
+      end
+    end
+  end
+
+  def test_emit_target
+    d = create_driver %[
+      tag test.anomaly
+      outlier_term 28
+      outlier_discount 0.05
+      score_term 28
+      score_discount 0.05
+      tick 10
+      smooth_term 3
+      target y
+    ]
+
+    data = 10.times.map { (rand * 100).to_i } + [0]
+    d.run do
+      data.each do |val|
+        d.emit({'y' => val})
+        r = d.instance.flush
+        assert_equal val, r['target']
+      end
+    end
+  end
+
+  def test_emit_when_target_does_not_exist
+    d = create_driver %[
+      tag test.anomaly
+      outlier_term 28
+      outlier_discount 0.05
+      score_term 28
+      score_discount 0.05
+      tick 10
+      smooth_term 3
+      target y
+    ]
+
+    d.run do
+      10.times do
+        d.emit({'foobar' => 999.99})
+        r = d.instance.flush
+        assert_equal nil, r
       end
     end
   end


### PR DESCRIPTION
Add empty check to avoid NaN. It happened when no data is coming yet or the target field does not exist. See the test.
