### PR TITLE
require_relative

### DIFF
--- a/lib/fluent/plugin/out_anomalydetect.rb
+++ b/lib/fluent/plugin/out_anomalydetect.rb
@@ -2,7 +2,7 @@ module Fluent
   class AnomalyDetectOutput < Output
     Fluent::Plugin.register_output('anomalydetect', self)
     
-    require 'fluent/plugin/change_finder'
+    require_relative 'change_finder'
     require 'pathname'
 
     config_param :outlier_term, :integer, :default => 28


### PR DESCRIPTION
Use `require_relative`, otherwise, the plugin does not load the correct `change_finder.rb` when an user copies plugin files into `fluent/plugin` directory. 
