### PR TITLE
add trend option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -82,6 +82,14 @@ If "store_file" option was specified, a historical stat will be stored to the fi
 
 If "threshold" option was specified, plugin only ouput when the anomalyscore is more than threshold.
 
+    <match access.**>
+      type anomalydetect
+      ...
+      trend up
+    </match>
+
+If "trend" option was specified, plugin only ouput when the input data tends to up (or down). 
+
 == Theory
 "データマイニングによる異常検知" http://amzn.to/XHXNun
 

--- a/lib/fluent/plugin/change_finder.rb
+++ b/lib/fluent/plugin/change_finder.rb
@@ -2,6 +2,7 @@
 module Fluent
   class ChangeFinder
     require 'matrix'
+    attr_reader :mu
 
     def initialize(term, r)
       @term = term

--- a/test/plugin/test_out_anomalydetect.rb
+++ b/test/plugin/test_out_anomalydetect.rb
@@ -246,4 +246,54 @@ class AnomalyDetectOutputTest < Test::Unit::TestCase
       end
     end
   end
+
+  def test_up_trend
+    d = create_driver %[
+      target y
+      trend up
+    ]
+
+    # should not output in down trend
+    d.run do
+      d.emit({'y' => 0.0}); d.instance.flush
+      d.emit({'y' => 0.0}); d.instance.flush
+      d.emit({'y' => 0.0}); d.instance.flush
+      d.emit({'y' => -1.0}); r = d.instance.flush
+      assert_equal nil, r
+    end
+
+    # should output in up trend
+    d.run do
+      d.emit({'y' => -1.0}); d.instance.flush
+      d.emit({'y' => -1.0}); d.instance.flush
+      d.emit({'y' => -1.0}); d.instance.flush
+      d.emit({'y' => 0.0}); r = d.instance.flush
+      assert_not_equal nil, r
+    end
+  end
+
+  def test_down_trend
+    d = create_driver %[
+      target y
+      trend down
+    ]
+    # should output in down trend
+    d.run do
+      d.emit({'y' => 0.0}); d.instance.flush
+      d.emit({'y' => 0.0}); d.instance.flush
+      d.emit({'y' => 0.0}); d.instance.flush
+      d.emit({'y' => -1.0}); r = d.instance.flush
+      assert_not_equal nil, r
+    end
+
+    # should not output in up tread
+    d.run do
+      d.emit({'y' => -1.0}); d.instance.flush
+      d.emit({'y' => -1.0}); d.instance.flush
+      d.emit({'y' => -1.0}); d.instance.flush
+      d.emit({'y' => 0.0})
+      r = d.instance.flush
+      assert_equal nil, r
+    end
+  end
 end


### PR DESCRIPTION
In my usecase, I wanted to detect downward trend only. So, I added `trend` option. 

> If "trend" option was specified, plugin only ouput when the input data tends to up (or down). 
