### PR TITLE
Fixed typo outiers -> outliers

### DIFF
--- a/lib/fluent/plugin/out_anomalydetect.rb
+++ b/lib/fluent/plugin/out_anomalydetect.rb
@@ -319,7 +319,7 @@ module Fluent
             @outliers     = stored[:outliers]
             @outlier_bufs = stored[:outlier_bufs]
             @scores       = stored[:scores]
-            @outiers.each {|outlier| outlier.log = log } # @log is not dumped, so have to set at here
+            @outliers.each {|outlier| outlier.log = log } # @log is not dumped, so have to set at here
           else
             log.warn "anomalydetect: configuration param was changed. ignore stored data"
           end


### PR DESCRIPTION
`@outiers.each {|outlier| outlier.log = log }` not work.
Fixed typo `@outiers` to `@outliers`.
Please merge the pull request.
