### PR TITLE
Fixed assign the Fluent::Log to Fluent::ChangeFinder

### DIFF
--- a/lib/fluent/plugin/change_finder.rb
+++ b/lib/fluent/plugin/change_finder.rb
@@ -69,7 +69,7 @@ module Fluent
 
       p = prob(xt, @sigma, x)
       s = score(p)
-      log.debug "change_finder:#{Thread.current.object_id} x:#{x} xt:#{xt} p:#{p} s:#{s} term:#{@term} r:#{@r} data:#{@data} mu:#{@mu} sigma:#{@sigma} c:#{@c}"
+      log.debug "change_finder:#{Thread.current.object_id} x:#{x} xt:#{xt} p:#{p} s:#{s} term:#{@term} r:#{@r} data:#{@data} mu:#{@mu} sigma:#{@sigma} c:#{@c}" if log.respond_to?(:debug)
       s
     end
 

--- a/lib/fluent/plugin/out_anomalydetect.rb
+++ b/lib/fluent/plugin/out_anomalydetect.rb
@@ -319,13 +319,28 @@ module Fluent
             @outliers     = stored[:outliers]
             @outlier_bufs = stored[:outlier_bufs]
             @scores       = stored[:scores]
-            @outliers.each {|outlier| outlier.log = log } # @log is not dumped, so have to set at here
+            inject_log(@scores)
+            inject_log(@outliers)
           else
             log.warn "anomalydetect: configuration param was changed. ignore stored data"
           end
         end
       rescue => e
         log.warn "anomalydetect: Can't load store_file #{e}"
+      end
+    end
+
+    def inject_log(obj)
+      case obj
+      when Array
+        obj.map{|o| log_injection(o) }
+      when Hash
+        obj.inject({}) do |hash, (k, v)|
+          hash[k] = log_injection(v)
+          hash
+        end
+      else
+        obj.log = log if obj.respond_to?(:log)
       end
     end
 


### PR DESCRIPTION
```
# change_finder.rb
def next(x)
...
      log.debug "change_finder:#{Thread.current.object_id} x:#{x} xt:#{xt} p:#{p} s:#{s} term:#{@term} r:#{@r} data:#{@data} mu:#{@mu} sigma:#{@sigma} c:#{@c}"
      s
end
```

`log.debug` isn't work.

```
# out_anomalydetect.rb
def load_from_file
...
            @outliers.each {|outlier| outlier.log = log } # @log is not dumped, so have to set at here
...
end
```

The reason why `@outliers` is nested hash(`outlier` isn't `Fluent::ChangeFinder`).

`@outliers` dump:

```
{:all=>{nil=>#<Fluent::ChangeFinder:0x007f2c3c08f628 @term=28, @r=0.05, @data=[...]>}}
```

This Pull Request is fixed assign the `Fluent::Log` to `Fluent::ChangeFinder`.
