### PR TITLE
Suppress uninitalized variable warnings

### DIFF
--- a/lib/fluent/plugin/out_anomalydetect.rb
+++ b/lib/fluent/plugin/out_anomalydetect.rb
@@ -85,6 +85,7 @@ module Fluent
         raise Fluent::ConfigError, "anomalydetect: aggregate allows tag/all"
       end
 
+      @tag_prefix = @tag_prefix_match = nil
       @tag_prefix = "#{@add_tag_prefix}." if @add_tag_prefix
       @tag_prefix_match = "#{@remove_tag_prefix}." if @remove_tag_prefix
       @tag_proc =


### PR DESCRIPTION
`@tag_prefix` and `@tag_prefix_match` should be initialized as `nil`.